### PR TITLE
feat(DLNA): implement settings page

### DIFF
--- a/frontend/components/System/SelectedDlnaProfile.vue
+++ b/frontend/components/System/SelectedDlnaProfile.vue
@@ -1,0 +1,924 @@
+<template>
+  <v-card class="selected-dlna-profile">
+    <v-row v-if="isDialog" class="ma-0 justify-space-between align-center">
+      <v-card-title>{{ selectedProfile.Name }}</v-card-title>
+      <v-btn icon class="mr-2" @click="$emit('close-dialog')">
+        <v-icon>mdi-close</v-icon>
+      </v-btn>
+    </v-row>
+    <v-card-title v-else>{{ currentProfile.Name }}</v-card-title>
+    <v-tabs v-model="tab" centered dark icons-and-text>
+      <v-tabs-slider />
+      <v-tab v-for="i in 9" :key="i" :href="'#tab-' + i">
+        {{
+          $t(
+            'settings.dlna.profile.' +
+              categories[i - 1].toLocaleString() +
+              '.title'
+          )
+        }}
+      </v-tab>
+    </v-tabs>
+    <v-tabs-items v-model="tab">
+      <v-tab-item value="tab-1">
+        <v-list>
+          <!-- General -->
+          <v-list-group :value="true">
+            <template #activator>
+              <v-list-item-title>
+                {{ $t('settings.dlna.profile.info.general.title') }}
+              </v-list-item-title>
+            </template>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="$t('settings.dlna.profile.info.general.name.text')"
+                />
+                <v-list-item-subtitle
+                  v-text="$t('settings.dlna.profile.info.general.name.info')"
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field v-model="currentProfile.Name" outlined dense />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.info.general.userLibrary.text')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.general.userLibrary.info')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-select
+                  v-model="currentProfile.UserId"
+                  :items="users"
+                  item-text="Name"
+                  item-value="Id"
+                  outlined
+                  dense
+                  clearable
+                  :label="$t('settings.dlna.DefaultUserId.selector')"
+                  reverse
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <!-- Supported Media Types -->
+            <v-list-group :value="true" no-action sub-group>
+              <template #activator>
+                <v-list-item-title>
+                  {{ $t('settings.dlna.profile.info.general.mediaTypes.text') }}
+                </v-list-item-title>
+              </template>
+              <v-list-item>
+                <v-list-item-action>
+                  <v-checkbox v-model="supportedMediaTypes" value="Audio" />
+                </v-list-item-action>
+                <v-list-item-content>
+                  <v-list-item-title
+                    v-text="
+                      $t('settings.dlna.profile.info.general.mediaTypes.audio')
+                    "
+                  />
+                </v-list-item-content>
+              </v-list-item>
+              <v-list-item>
+                <v-list-item-action>
+                  <v-checkbox v-model="supportedMediaTypes" value="Photo" />
+                </v-list-item-action>
+                <v-list-item-content>
+                  <v-list-item-title
+                    v-text="
+                      $t('settings.dlna.profile.info.general.mediaTypes.photo')
+                    "
+                  />
+                </v-list-item-content>
+              </v-list-item>
+              <v-list-item>
+                <v-list-item-action>
+                  <v-checkbox v-model="supportedMediaTypes" value="Video" />
+                </v-list-item-action>
+                <v-list-item-content>
+                  <v-list-item-title
+                    v-text="
+                      $t('settings.dlna.profile.info.general.mediaTypes.video')
+                    "
+                  />
+                </v-list-item-content>
+              </v-list-item>
+            </v-list-group>
+            <!-- back to normal -->
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.info.general.maxStreamQuality.text'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.info.general.maxStreamQuality.info'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model.number="currentProfile.MaxStreamingBitrate"
+                  type="number"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.info.general.musicTranscodeQuality.text'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.info.general.musicTranscodeQuality.info'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model.number="
+                    currentProfile.MusicStreamingTranscodingBitrate
+                  "
+                  type="number"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+          </v-list-group>
+
+          <!-- Display -->
+          <v-list-group :value="false">
+            <template #activator>
+              <v-list-item-title>
+                {{ $t('settings.dlna.profile.info.display.title') }}
+              </v-list-item-title>
+            </template>
+            <v-list-item>
+              <v-list-item-action>
+                <v-checkbox v-model="currentProfile.RequiresPlainFolders" />
+              </v-list-item-action>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.info.display.plainFolder.text')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.display.plainFolder.info')
+                  "
+                />
+              </v-list-item-content>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-action>
+                <v-checkbox v-model="currentProfile.RequiresPlainVideoItems" />
+              </v-list-item-action>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.info.display.plainVideo.text')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.display.plainVideo.info')
+                  "
+                />
+              </v-list-item-content>
+            </v-list-item>
+          </v-list-group>
+
+          <!-- Image Settings -->
+          <v-list-group :value="false">
+            <template #activator>
+              <v-list-item-title>
+                {{ $t('settings.dlna.profile.info.image.title') }}
+              </v-list-item-title>
+            </template>
+            <v-list-item>
+              <v-list-item-action>
+                <v-checkbox v-model="currentProfile.EnableAlbumArtInDidl" />
+              </v-list-item-action>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="$t('settings.dlna.profile.info.image.embedDidl.text')"
+                />
+                <v-list-item-subtitle
+                  v-text="$t('settings.dlna.profile.info.image.embedDidl.info')"
+                />
+              </v-list-item-content>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-action>
+                <v-checkbox
+                  v-model="currentProfile.EnableSingleAlbumArtLimit"
+                />
+              </v-list-item-action>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.info.image.singleEmbed.text')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.image.singleEmbed.info')
+                  "
+                />
+              </v-list-item-content>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="$t('settings.dlna.profile.info.image.albumPN.text')"
+                />
+                <v-list-item-subtitle
+                  v-text="$t('settings.dlna.profile.info.image.albumPN.info')"
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.AlbumArtPn"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.info.image.albumArtMaxWidth')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.image.albumMaxDimension')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.MaxAlbumArtWidth"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.info.image.albumArtMaxHeight')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.image.albumMaxDimension')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.MaxAlbumArtHeight"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="$t('settings.dlna.profile.info.image.iconMaxWidth')"
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.image.iconMaxDimension')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.MaxIconWidth"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="$t('settings.dlna.profile.info.image.iconMaxHeight')"
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.info.image.iconMaxDimension')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.MaxIconHeight"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+          </v-list-group>
+        </v-list>
+      </v-tab-item>
+
+      <v-tab-item value="tab-2">
+        <v-list>
+          <!-- Identification -->
+          <v-list-group :value="true">
+            <template #activator>
+              <v-list-item-title>
+                {{ $t('settings.dlna.profile.identification.device.title') }}
+              </v-list-item-title>
+            </template>
+            <v-card-text>
+              {{ $t('settings.dlna.profile.identification.device.info') }}
+            </v-card-text>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.device.friendlyName'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.FriendlyName"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.device.manufacturer'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.Manufacturer"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.device.manufacturerUrl'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.ManufacturerUrl"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.modelName')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.ModelName"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.device.modelNumber'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.ModelNumber"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.device.modelDescription'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.ModelDescription"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.modelUrl')
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.ModelUrl"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.device.serialNumber'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.SerialNumber"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.device.deviceDescription'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t('settings.dlna.profile.identification.device.infoText')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Identification.ModelDescription"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+          </v-list-group>
+
+          <!-- Server Settings -->
+          <v-list-group :value="false">
+            <template #activator>
+              <v-list-item-title>
+                {{ $t('settings.dlna.profile.identification.server.title') }}
+              </v-list-item-title>
+            </template>
+            <v-card-text>
+              {{ $t('settings.dlna.profile.identification.server.info') }}
+            </v-card-text>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.friendlyName'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.FriendlyName"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.manufacturer'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.Manufacturer"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.manufacturerUrl'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.ManufacturerUrl"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.identification.server.modelName')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.ModelName"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.modelNumber'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.ModelNumber"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.modelDescription'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.ModelDescription"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t('settings.dlna.profile.identification.server.modelUrl')
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.ModelUrl"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.serialNumber'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.SerialNumber"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.protocolInfo.text'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.protocolInfo.info'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.ProtocolInfo"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.sonyAggregationFlags.text'
+                    )
+                  "
+                />
+                <v-list-item-subtitle
+                  v-text="
+                    $t(
+                      'settings.dlna.profile.identification.server.sonyAggregationFlags.info'
+                    )
+                  "
+                />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-text-field
+                  v-model="currentProfile.SonyAggregationFlags"
+                  outlined
+                  dense
+                />
+              </v-list-item-action>
+            </v-list-item>
+          </v-list-group>
+        </v-list>
+      </v-tab-item>
+
+      <v-tab-item value="tab-3">
+        <v-card>
+          <v-card-text>
+            {{ $t('settings.dlna.profile.subtitle.text') }}
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+
+      <v-tab-item value="tab-4">
+        <v-card>
+          <v-card-text>
+            {{ $t('settings.dlna.profile.directPlay.text') }}
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+
+      <v-tab-item value="tab-5">
+        <v-card>
+          <v-card-text>
+            {{ $t('settings.dlna.profile.transcoding.text') }}
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+
+      <v-tab-item value="tab-6">
+        <v-card>
+          <v-card-text>
+            {{ $t('settings.dlna.profile.containers.text') }}
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+
+      <v-tab-item value="tab-7">
+        <v-card>
+          <v-card-text>
+            {{ $t('settings.dlna.profile.codecs.text') }}
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+
+      <v-tab-item value="tab-8">
+        <v-card>
+          <v-card-text>
+            {{ $t('settings.dlna.profile.responses.text') }}
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+
+      <v-tab-item value="tab-9">
+        <v-card>
+          <v-card-text>
+            {{ $t('settings.dlna.profile.xml.text') }}
+          </v-card-text>
+        </v-card>
+      </v-tab-item>
+    </v-tabs-items>
+    <v-card-actions>
+      <v-btn color="success" @click="$emit('save-selected', currentProfile)">
+        {{
+          isCustomProfile
+            ? $t('settings.dlna.profile.save')
+            : $t('settings.dlna.profile.saveNew')
+        }}
+      </v-btn>
+      <v-btn
+        v-if="isCustomProfile"
+        color="error"
+        @click="$emit('delete-selected')"
+      >
+        {{ $t('settings.devices.delete') }}
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { DeviceProfile, UserDto } from '@jellyfin/client-axios';
+
+enum DlnaProfileCategories {
+  info,
+  identification,
+  subtitle,
+  directPlay,
+  transcoding,
+  containers,
+  codecs,
+  responses,
+  xml
+}
+
+export default Vue.extend({
+  props: {
+    selectedProfile: {
+      type: Object as () => DeviceProfile,
+      default: (): DeviceProfile => {
+        return {};
+      }
+    },
+    isCustomProfile: {
+      default: false,
+      type: Boolean
+    },
+    users: {
+      type: Array as () => UserDto[],
+      default: () => undefined
+    },
+    isDialog: {
+      default: false,
+      type: Boolean
+    }
+  },
+  data() {
+    return {
+      categories: DlnaProfileCategories,
+      tab: null,
+      currentProfile: undefined as DeviceProfile | undefined,
+      supportedMediaTypes: [] as Array<string> | undefined
+    };
+  },
+  watch: {
+    supportedMediaTypes() {
+      if (this.currentProfile) {
+        this.currentProfile.SupportedMediaTypes =
+          this.supportedMediaTypes?.join(',');
+      }
+    }
+  },
+  beforeMount() {
+    this.bindToData();
+  },
+  methods: {
+    bindToData() {
+      const tempProfile = JSON.parse(JSON.stringify(this.selectedProfile));
+
+      this.currentProfile = tempProfile;
+      this.supportedMediaTypes =
+        tempProfile.SupportedMediaTypes?.split(',') || [];
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.selected-dlna-profile {
+  width: 80em;
+}
+</style>

--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -314,6 +314,175 @@
       "revokeFailure": "Error revoking API key",
       "revokeSuccess": "Successfully revoked API key"
     },
+    "dlna": {
+      "dlna": "DLNA",
+      "EnablePlayTo": {
+        "text": "Enable DLNA Play To",
+        "description": "Detect devices within your network and offer the ability to control them remotely."
+      },
+      "EnableDebugLog": {
+        "text": "Enable DLNA debug logging",
+        "description": "Create large log files and should only be used as needed for troubleshooting purposes."
+      },
+      "ClientDiscoveryIntervalSeconds": {
+        "text": "Client discovery interval",
+        "description": "Determines the duration in seconds between SSDP searches."
+      },
+      "EnableServer": {
+        "text": "Enable DLNA server",
+        "description": "Allows UPnP devices on your network to browse and play content."
+      },
+      "BlastAliveMessages": {
+        "text": "Blast alive messages",
+        "description": "Enable this if the server is not detected reliably by other UPnP devices on your network."
+      },
+      "AliveMessageIntervalSeconds": {
+        "text": "Alive message interval",
+        "description": "Determines the duration in seconds between blast alive messages."
+      },
+      "DefaultUserId": {
+        "text": "Default user",
+        "description": "Determines which user library should be displayed on connected devices. This can be overridden for each device using profiles.",
+        "selector": "Select default user"
+      },
+      "profile": {
+        "new": "New Profile",
+        "name": "Profile name",
+        "custom": {
+          "text": "Custom profiles",
+          "subtitle": "Create a custom profile to target a new device or override a system profile."
+        },
+        "system": {
+          "text": "System profiles",
+          "subtitle": "System profiles are read-only. Changes to a system profile will be saved to a new custom profile."
+        },
+        "saveNew": "Save as new custom profile",
+        "save": "Save profile",
+        "info": {
+          "title": "Info",
+          "general": {
+            "title": "General settings",
+            "name": {
+              "text": "Name",
+              "info": "Set the name of this profile."
+            },
+            "userLibrary": {
+              "text": "User library",
+              "info": "Select which user library to display to the device. Leave empty to inherit the default setting."
+            },
+            "mediaTypes": {
+              "text": "Supported Media Types",
+              "audio": "Audio",
+              "video": "Video",
+              "photo": "Photo"
+            },
+            "maxStreamQuality": {
+              "text": "Maximum streaming quality",
+              "info": "Specify a maximum bitrate when streaming."
+            },
+            "musicTranscodeQuality": {
+              "text": "Music transcoding bitrate",
+              "info": "Specify a maximum bitrate when streaming music."
+            }
+          },
+          "display": {
+            "title": "Display Settings",
+            "plainFolder": {
+              "text": "Display all folders as plain storage folders",
+              "info": "All folders are represented in DIDL as \"object.container.storageFolder\" instead of a more specific type, such as \"object.container.person.musicArtist\"."
+            },
+            "plainVideo": {
+              "text": "Display all videos as plain video items",
+              "info": "All videos are represented in DIDL as \"object.item.videoItem\" instead of a more specific type, such as \"object.item.videoItem.movie\"."
+            }
+          },
+          "image": {
+            "title": "Image Settings",
+            "albumMaxDimension": "Maximum resolution of album art exposed via the upnp:albumArtURI property.",
+            "iconMaxDimension": "Maximum resolution of icons exposed via the upnp:icon property.",
+            "embedDidl": {
+              "text": "Embed album art in Didl",
+              "info": "Some devices prefer this method for obtaining album art. Others may fail to play with this option enabled."
+            },
+            "singleEmbed": {
+              "text": "Limit to single embedded image",
+              "info": "Some devices will not render properly if multiple images are embedded within Didl."
+            },
+            "albumPN": {
+              "text": "Album art PN",
+              "info": "PN used for album art, within the dlna:profileID attribute on upnp:albumArtURI. Some devices require a specific value, regardless of the size of the image."
+            },
+            "albumArtMaxWidth": "Album art max width",
+            "albumArtMaxHeight": "Album art max height",
+            "iconMaxWidth": "Icon maximum width",
+            "iconMaxHeight": "Icon maximum height"
+          }
+        },
+        "identification": {
+          "title": "Identification",
+          "device": {
+            "title": "Device identification",
+            "info": "Enter at least one identification criteria.",
+            "infoText": "A case-insensitive substring or regex expression.",
+            "friendlyName": "Friendly name",
+            "manufacturer": "Manufacturer",
+            "manufacturerUrl": "Manufacturer URL",
+            "modelName": "Model name",
+            "modelNumber": "Model number",
+            "modelDescription": "Model description",
+            "modelUrl": "Model URL",
+            "serialNumber": "Serial number",
+            "deviceDescription": "Device description"
+          },
+          "server": {
+            "title": "Server identification",
+            "info": "These values control how the server will present itself to clients.",
+            "friendlyName": "Friendly name",
+            "manufacturer": "Manufacturer",
+            "manufacturerUrl": "Manufacturer URL",
+            "modelName": "Model name",
+            "modelNumber": "Model number",
+            "modelDescription": "Model description",
+            "modelUrl": "Model URL",
+            "serialNumber": "Serial number",
+            "protocolInfo": {
+              "text": "Protocol info",
+              "info": "The value that will be used when responding to GetProtocolInfo requests from the device."
+            },
+            "sonyAggregationFlags": {
+              "text": "Sony aggregation flags",
+              "info": "Determines the content of the aggreagationFlags element in the urn:schemas-sonycom:av namespace."
+            }
+          }
+        },
+        "subtitle": {
+          "title": "Subtitle"
+        },
+        "directPlay": {
+          "title": "Direct Play",
+          "text": "Add direct play profiles to indicate which formats the device can handle natively."
+        },
+        "transcoding": {
+          "title": "Transcoding",
+          "text": "Add transcoding profiles to indicate which formats should be used when transcoding is required."
+        },
+        "containers": {
+          "title": "Containers",
+          "text": "Container profiles indicate the limitations of a device when playing specific formats. If a limitation applies then the media will be transcoded, even if the format is configured for direct play."
+        },
+        "codecs": {
+          "title": "Codecs",
+          "text": "Codec profiles indicate the limitations of a device when playing specific codecs. If a limitation applies then the media will be transcoded, even if the codec is configured for direct play."
+        },
+        "responses": {
+          "title": "Responses",
+          "text": "Response profiles provide a way to customize information sent to the device when playing certain kinds of media."
+        },
+        "xml": {
+          "title": "XML"
+        }
+      }
+    },
     "devices": {
       "appName": "App name",
       "appVersion": "App version",

--- a/frontend/pages/settings/dlna.vue
+++ b/frontend/pages/settings/dlna.vue
@@ -1,0 +1,249 @@
+<template>
+  <settings-page page-title="settings.dlna.dlna">
+    <template #actions>
+      <v-btn
+        rel="noreferrer noopener"
+        href="https://jellyfin.org/docs/general/networking/dlna.html"
+        target="_blank"
+      >
+        {{ $t('settings.help') }}
+      </v-btn>
+    </template>
+    <template #content>
+      <v-col cols="12" md="6" lg="5" class="py-4">
+        <v-card class="mb-4">
+          <v-list two-line flat>
+            <v-list-item-group>
+              <v-list-item
+                v-for="dlnaSettingName in Object.keys(bindToRelevantConfig)"
+                :key="dlnaSettingName"
+              >
+                <v-list-item-content>
+                  <v-list-item-title
+                    v-text="$t('settings.dlna.' + dlnaSettingName + '.text')"
+                  />
+                  <v-list-item-subtitle
+                    v-text="
+                      $t('settings.dlna.' + dlnaSettingName + '.description')
+                    "
+                  />
+                </v-list-item-content>
+                <v-list-item-action>
+                  <v-switch
+                    v-if="typeof dlnaSettings[dlnaSettingName] === 'boolean'"
+                    v-model="dlnaSettings[dlnaSettingName]"
+                    @change="storeDlnaConfiguration"
+                  />
+                  <v-text-field
+                    v-if="typeof dlnaSettings[dlnaSettingName] === 'number'"
+                    v-model.number="dlnaSettings[dlnaSettingName]"
+                    type="number"
+                    outlined
+                    reverse
+                    dense
+                    @change="storeDlnaConfiguration"
+                  />
+                  <v-select
+                    v-if="
+                      typeof dlnaSettings[dlnaSettingName] === 'string' ||
+                      typeof dlnaSettings[dlnaSettingName] === 'undefined'
+                    "
+                    v-model="dlnaSettings[dlnaSettingName]"
+                    :items="users"
+                    item-text="Name"
+                    item-value="Id"
+                    :label="$t('settings.dlna.DefaultUserId.selector')"
+                    reverse
+                    dense
+                    outlined
+                    @change="storeDlnaConfiguration"
+                  />
+                </v-list-item-action>
+              </v-list-item>
+            </v-list-item-group>
+          </v-list>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="6" lg="5" class="py-4">
+        <v-card class="mb-4">
+          <v-card-title>
+            {{ $t('settings.dlna.profile.custom.text') }}
+            <v-spacer />
+            <v-btn class="ml-a" color="primary">
+              {{ $t('settings.dlna.profile.new') }}
+            </v-btn>
+          </v-card-title>
+          <v-data-table
+            :headers="headers"
+            :items="userProfiles"
+            :items-per-page="4"
+            :footer-props="{
+              itemsPerPageOptions: [4, 8, 12, 16, -1]
+            }"
+            @click:row="setSelectedDevice"
+          />
+        </v-card>
+        <v-card class="mb-4">
+          <v-card-title>
+            {{ $t('settings.dlna.profile.system.text') }}
+          </v-card-title>
+          <v-data-table
+            :headers="headers"
+            :items="systemProfiles"
+            :items-per-page="4"
+            :footer-props="{
+              itemsPerPageOptions: [4, 8, 12, 16, -1]
+            }"
+            @click:row="setSelectedDevice"
+          />
+        </v-card>
+      </v-col>
+      <v-dialog v-model="deviceInfoDialog" width="fit-content">
+        <selected-dlna-profile
+          v-if="selectedProfile.Name"
+          :selected-profile="selectedProfile"
+          :is-dialog="true"
+          :is-custom-profile="isCustomProfile"
+          :users="users"
+          @close-dialog="closeDialog"
+          @save-selected="saveProfile"
+          @delete-selected="deleteSelectedProfile"
+        />
+      </v-dialog>
+    </template>
+  </settings-page>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import {
+  DeviceProfile,
+  DeviceProfileInfo,
+  DeviceProfileType,
+  UserDto
+} from '@jellyfin/client-axios';
+import isNil from 'lodash/isNil';
+import SelectedDlnaProfile from '~/components/System/SelectedDlnaProfile.vue';
+
+/**
+ * We need to define those interfaces here as the axios hook for
+ * $api.configuration.getNamedConfiguration() returns an
+ * any typed object which we cannot use further down the line.
+ */
+interface RelevantConfig {
+  EnablePlayTo: boolean;
+  EnableDebugLog: boolean;
+  ClientDiscoveryIntervalSeconds: number;
+  EnableServer: boolean;
+  BlastAliveMessages: boolean;
+  AliveMessageIntervalSeconds: number;
+  DefaultUserId: string;
+}
+
+interface DlnaNamedConfiguration extends RelevantConfig {
+  EnablePlayToTracing: boolean;
+  BlastAliveMessageIntervalSeconds: number;
+  AutoCreatePlayToProfiles: boolean;
+  SendOnlyMatchedHost: boolean;
+}
+
+export default Vue.extend({
+  components: { SelectedDlnaProfile },
+  async asyncData({ $api }) {
+    const dlnaSettings = (
+      await $api.configuration.getNamedConfiguration({ key: 'dlna' })
+    ).data;
+
+    const dlnaProfiles = (await $api.dlna.getProfileInfos()).data;
+    const users = (await $api.user.getUsers()).data;
+
+    return { dlnaSettings, dlnaProfiles, users };
+  },
+  data() {
+    return {
+      dlnaSettings: {} as DlnaNamedConfiguration,
+      dlnaProfiles: [] as DeviceProfileInfo[],
+      users: [] as UserDto[],
+      selectedProfile: {} as DeviceProfile,
+      deviceInfoDialog: false,
+      isCustomProfile: false,
+      currentProfileId: ''
+    };
+  },
+  computed: {
+    headers(): { text: string; value: string }[] {
+      return [
+        {
+          text: this.$t('settings.dlna.profile.name'),
+          value: 'Name'
+        }
+      ];
+    },
+    userProfiles(): DeviceProfileInfo[] {
+      return this.dlnaProfiles.filter(
+        (profile) => profile.Type === DeviceProfileType.User
+      );
+    },
+    systemProfiles(): DeviceProfileInfo[] {
+      return this.dlnaProfiles.filter(
+        (profile) => profile.Type === DeviceProfileType.System
+      );
+    },
+    bindToRelevantConfig(): RelevantConfig {
+      return {
+        EnablePlayTo: this.dlnaSettings.EnablePlayTo,
+        EnableDebugLog: this.dlnaSettings.EnableDebugLog,
+        ClientDiscoveryIntervalSeconds:
+          this.dlnaSettings.ClientDiscoveryIntervalSeconds,
+        EnableServer: this.dlnaSettings.EnableServer,
+        BlastAliveMessages: this.dlnaSettings.BlastAliveMessages,
+        AliveMessageIntervalSeconds:
+          this.dlnaSettings.AliveMessageIntervalSeconds,
+        DefaultUserId: this.dlnaSettings.DefaultUserId
+      };
+    }
+  },
+  methods: {
+    async storeDlnaConfiguration(): Promise<void> {
+      await this.$api.configuration.updateNamedConfiguration(
+        {
+          key: 'dlna'
+        },
+        { data: this.dlnaSettings }
+      );
+    },
+    async setSelectedDevice(selectedDevice: DeviceProfileInfo): Promise<void> {
+      if (!isNil(selectedDevice)) {
+        this.currentProfileId = selectedDevice.Id as string;
+        this.selectedProfile = (
+          await this.$api.dlna.getProfile({
+            profileId: selectedDevice.Id as string
+          })
+        ).data;
+        this.isCustomProfile = this.userProfiles.includes(selectedDevice);
+        this.deviceInfoDialog = true;
+      }
+    },
+    async saveProfile(profile: DeviceProfile): Promise<void> {
+      await this.$api.dlna.updateProfile({
+        profileId: this.currentProfileId,
+        deviceProfile: profile
+      });
+      this.dlnaProfiles = (await this.$api.dlna.getProfileInfos()).data;
+      this.closeDialog();
+    },
+    async deleteSelectedProfile(): Promise<void> {
+      await this.$api.dlna.deleteProfile({
+        profileId: this.currentProfileId
+      });
+      this.dlnaProfiles = (await this.$api.dlna.getProfileInfos()).data;
+      this.closeDialog();
+    },
+    closeDialog(): void {
+      this.deviceInfoDialog = false;
+      this.isCustomProfile = false;
+      this.selectedProfile = {};
+    }
+  }
+});
+</script>

--- a/frontend/pages/settings/index.vue
+++ b/frontend/pages/settings/index.vue
@@ -193,7 +193,8 @@ export default Vue.extend({
           {
             icon: 'mdi-dlna',
             name: this.$t('settingsSections.dlna.name'),
-            description: this.$t('settingsSections.dlna.description')
+            description: this.$t('settingsSections.dlna.description'),
+            link: 'settings/dlna'
           },
           {
             icon: 'mdi-television-classic',


### PR DESCRIPTION
This PR tracks the progress of the implementation of the DLNA settings page. Required for this to be complete the following things have to be done:

- [x] create page
- [x] bind data from DlnaNamedConfig
- [x] bind data from DlnaProfiles
- [ ] allow creation of DlnaProfiles
- [ ] allow editing for DlnaProfiles
- [x] adding translation strings

As for the design I tried sticking to the scheme which is already defined by the pages of `settings` as well as the `devices` and `api keys`. With this card based approch I'm planning to unify the "devices" and "settings" pages which used to be separated by a drawer into a single one which should provide a better user experience.

## Things I'm unsure of:
- currently there is no header for either of the cards (which might be confusing for inexperienced users)
